### PR TITLE
Allow a fallback if no view-specific entry point exists

### DIFF
--- a/RequireJsNet/RequireRendererConfiguration.cs
+++ b/RequireJsNet/RequireRendererConfiguration.cs
@@ -19,6 +19,8 @@ namespace RequireJsNet
 
         private string entryPointRoot = "~/Scripts/";
 
+        private string fallbackEntryPoint = null;
+
         private bool loadOverrides = true;
 
         private IList<string> configPaths = new[] { "~/RequireJS.json" };
@@ -107,6 +109,22 @@ namespace RequireJsNet
             set
             {
                 entryPointRoot = value;
+            }
+        }
+
+        /// <summary>
+        /// Default entry point if view-specific entry point is not found
+        /// </summary>
+        public string FallbackEntryPoint
+        {
+            get
+            {
+                return fallbackEntryPoint;
+            }
+
+            set
+            {
+                fallbackEntryPoint = value;
             }
         }
 


### PR DESCRIPTION
Currently the RequireJS HTML Helper produces no output if a view-specific entry point script (e.g. Controllers/Home/index.js) is not found.  This extends the script path to fall back to a global entry point, which defaults to "app-global". 

The module name of the global entry point can be defined when calling the helper:

```csharp
@Html.RenderRequireJsSetup(new RequireRendererConfiguration
{
    RequireJsUrl = Url.Content("~/Scripts/require.js"),
    BaseUrl = Url.Content("~/Scripts/"),
    FallbackEntryPoint = "app-global",
}
```