### PR TITLE
Compare EntryPointRoot against baseUrl instead of "~/Scripts"

### DIFF
--- a/RequireJsNet/EntryPointResolver/DefaultEntryPointResolver.cs
+++ b/RequireJsNet/EntryPointResolver/DefaultEntryPointResolver.cs
@@ -1,4 +1,5 @@
 ﻿using RequireJsNet.Helpers;
+using System;
 using System.IO;
 using System.Web;
 using System.Web.Mvc;
@@ -16,6 +17,12 @@ namespace RequireJsNet.EntryPointResolver
             var rootUrl = string.Empty;
             var withBaseUrl = true;
             var server = viewContext.HttpContext.Server;
+
+            if (String.IsNullOrWhiteSpace(entryPointRoot))
+            {
+                entryPointRoot = baseUrl;            
+            }
+
             var resolvedEntryPointRoot = UrlHelper.GenerateContentUrl(entryPointRoot, viewContext.HttpContext);
 
             if (resolvedEntryPointRoot != baseUrl)

--- a/RequireJsNet/EntryPointResolver/DefaultEntryPointResolver.cs
+++ b/RequireJsNet/EntryPointResolver/DefaultEntryPointResolver.cs
@@ -16,8 +16,9 @@ namespace RequireJsNet.EntryPointResolver
             var rootUrl = string.Empty;
             var withBaseUrl = true;
             var server = viewContext.HttpContext.Server;
+            var resolvedEntryPointRoot = UrlHelper.GenerateContentUrl(entryPointRoot, viewContext.HttpContext);
 
-            if (entryPointRoot != DefaultEntryPointRoot)
+            if (resolvedEntryPointRoot != baseUrl)
             {
                 // entryPointRoot is different from default.
                 if ((entryPointRoot.StartsWith("~") || entryPointRoot.StartsWith("/")))


### PR DESCRIPTION
The DefaultEntryPointResolver skips determining the EntryPointRoot if the configured value matches the '~/Scripts'.  This works provided that the baseUrl is set to '~/Scripts'.  Comparing the EntryPointRoot against the actual baseUrl will allow for instances where the baseUrl does not equal '~/Scripts'.

Additional check requires that EntryPointRoot has a value.  If EntryPointRoot is blank prior to being resolved, it is set equal to baseUrl.