### PR TITLE
Added dir aliases support for requirejs config.

### DIFF
--- a/RequireJsNet.Compressor/AutoDependency/ScriptProcessor.cs
+++ b/RequireJsNet.Compressor/AutoDependency/ScriptProcessor.cs
@@ -165,14 +165,20 @@ namespace RequireJsNet.Compressor.AutoDependency
 
         private string GetModulePath(string name)
         {
-            var result = name;
-            var pathEl = configuration.Paths.PathList.Where(r => r.Key.ToLower() == name.ToLower()).FirstOrDefault();
-            if (pathEl != null)
+            var paths = name.Split('/');
+            var result = new StringBuilder();
+            foreach (var path in paths)
             {
-                result = pathEl.Value;
+                var pathEl = configuration.Paths.PathList.FirstOrDefault(r => r.Key.ToLower() == path.ToLower());
+                result.Append(pathEl != null ? pathEl.Value : path);
+
+                if (!paths.Last().Equals(path))
+                {
+                    result.Append("/");
+                }
             }
 
-            return result;
+            return result.ToString();
         }
 
         private void EnsureHasRange(SyntaxNode node, List<ScriptLine> lineList)


### PR DESCRIPTION
According to requirejs specification we are allowed to define dir alias in 'paths' section. However, the compressor compares only the full dependency entry name (module path) with the entries defined in 'paths' section.

For example if we would have a following requirejs module:
define(['lib/myLibrary'], function() { });

then compressor would look for whole 'lib/myLibrary' inside of the requirejs config paths section. Instead it should look up each part of the module path individually ('lib', 'myLibrary') when generating bundle.