### PR TITLE
Exclude from auto-bundles

### DIFF
--- a/RequireJsNet.Compressor/Models/RequireFile.cs
+++ b/RequireJsNet.Compressor/Models/RequireFile.cs
@@ -16,5 +16,7 @@ namespace RequireJsNet.Compressor.Models
         public string Content { get; set; }
 
         public List<string> Dependencies { get; set; }
+
+        public string CompressionType { get; set; }
     }
 }

--- a/RequireJsNet.Compressor/RequireProcessing/AutoBundleConfigProcessor.cs
+++ b/RequireJsNet.Compressor/RequireProcessing/AutoBundleConfigProcessor.cs
@@ -121,6 +121,11 @@ namespace RequireJsNet.Compressor.RequireProcessing
                 while (fileQueue.Any())
                 {
                     var file = fileQueue.Dequeue();
+
+                    var useShallowExcludes = false;
+                    if (!useShallowExcludes && excludedFiles.Contains(file))
+                        continue;
+
                     var fileText = File.ReadAllText(file, encoding);
                     var relativePath = PathHelpers.GetRelativePath(file, EntryPoint + Path.DirectorySeparatorChar);
                     var processor = new ScriptProcessor(relativePath, fileText, Configuration);
@@ -142,7 +147,7 @@ namespace RequireJsNet.Compressor.RequireProcessing
                 {
                     var addedFiles = bundleResult.Files.Select(r => r.FileName).ToList();
                     var noDeps = tempFileList.Where(r => !r.Dependencies.Any()
-                                                        || r.Dependencies.All(x => addedFiles.Contains(x))).ToList();
+                                                        || r.Dependencies.All(x => addedFiles.Contains(x) || excludedFiles.Contains(x))).ToList();
                     if (!noDeps.Any())
                     {
                         noDeps = tempFileList.ToList();

--- a/RequireJsNet.Compressor/RequireProcessing/AutoBundleConfigProcessor.cs
+++ b/RequireJsNet.Compressor/RequireProcessing/AutoBundleConfigProcessor.cs
@@ -137,7 +137,8 @@ namespace RequireJsNet.Compressor.RequireProcessing
                                          {
                                              Name = file,
                                              Content = result,
-                                             Dependencies = dependencies
+                                             Dependencies = dependencies,
+                                             CompressionType = bundle.CompressionType //TODO: Should be allowed to override for individual files in RequireJS.json too
                                          });
 
                     this.EnqueueFileList(tempFileList, fileQueue, dependencies);
@@ -155,7 +156,7 @@ namespace RequireJsNet.Compressor.RequireProcessing
 
                     foreach (var requireFile in noDeps)
                     {
-                        bundleResult.Files.Add(new FileSpec(requireFile.Name, string.Empty) { FileContent = requireFile.Content });
+                        bundleResult.Files.Add(new FileSpec(requireFile.Name, requireFile.CompressionType) { FileContent = requireFile.Content });
                         tempFileList.Remove(requireFile);
                     }    
                 }

--- a/RequireJsNet/Configuration/ConfigMerger.cs
+++ b/RequireJsNet/Configuration/ConfigMerger.cs
@@ -156,7 +156,12 @@ namespace RequireJsNet.Configuration
                     {
                         existing.OutputPath = autoBundle.OutputPath;    
                     }
-                    
+
+                    if (!string.IsNullOrEmpty(autoBundle.CompressionType))
+                    {
+                        existing.CompressionType = autoBundle.CompressionType;
+                    }
+
                     foreach (var include in autoBundle.Includes)
                     {
                         existing.Includes.Add(include);

--- a/RequireJsNet/Configuration/JsonReader.cs
+++ b/RequireJsNet/Configuration/JsonReader.cs
@@ -293,6 +293,7 @@ namespace RequireJsNet.Configuration
                             if (valueObj != null)
                             {
                                 currentBundle.OutputPath = valueObj["outputPath"] != null ? valueObj["outputPath"].ToString() : null;
+                                currentBundle.CompressionType = valueObj["compressionType"] != null ? valueObj["compressionType"].ToString() : null;
                                 currentBundle.ContainingConfig = Path;
                                 currentBundle.Includes = new List<AutoBundleItem>();
                                 if (valueObj["include"] != null)

--- a/RequireJsNet/Configuration/JsonWriter.cs
+++ b/RequireJsNet/Configuration/JsonWriter.cs
@@ -177,6 +177,11 @@ namespace RequireJsNet.Configuration
                             obj.OutputPath = r.OutputPath;
                         }
 
+                        if (!string.IsNullOrEmpty(r.CompressionType))
+                        {
+                            obj.CompressionType = r.CompressionType;
+                        }
+
                         if (r.Includes != null && r.Includes.Any())
                         {
                             obj.Include = AutoBundleContentSelector(r.Includes);

--- a/RequireJsNet/Configuration/XmlReader.cs
+++ b/RequireJsNet/Configuration/XmlReader.cs
@@ -213,6 +213,7 @@ namespace RequireJsNet.Configuration
                        {
                            Id = element.ReadStringAttribute("id"),
                            OutputPath = element.ReadStringAttribute("outputPath"),
+                           CompressionType = element.ReadStringAttribute("compressionType"),
                            Includes = element.Descendants("include").Select(AutoBundleItemReader).ToList(),
                            Excludes = element.Descendants("exclude").Select(AutoBundleItemReader).ToList(),
                            ContainingConfig = Path

--- a/RequireJsNet/Models/AutoBundle.cs
+++ b/RequireJsNet/Models/AutoBundle.cs
@@ -20,5 +20,7 @@ namespace RequireJsNet.Models
         public List<AutoBundleItem> Excludes { get; set; }
 
         public string ContainingConfig { get; set; }
+
+        public string CompressionType { get; set; }
     }
 }


### PR DESCRIPTION
I tried using RequireJS.Net with a simple mvc.net application using jquery-2.2.0 and just couldn't get it working. 

* This PR completes the Exclude support for AutoBundles that seems to be missing.

* The PR also adds support for selecting CompressionType for the YUICompressor. It defaults to "standard" to not change the existing behaviour, but if you add "compressionType": "none" to an autoBundle the files in that bundle will only be concatenated without being minified.

After putting jquery-2.2.0 in its own bundle and suppressing minification and then excluding jquery from all other bundles, I get the bundles to compile like I want.